### PR TITLE
Add different media screen fitting modes

### DIFF
--- a/server/Episememe.Api/Configuration/FileUploadLimits.cs
+++ b/server/Episememe.Api/Configuration/FileUploadLimits.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Episememe.Api.Configuration
+{
+    public static class FileUploadLimits
+    {
+        public static IServiceCollection ConfigureFileUploadLimits(this IServiceCollection services)
+        {
+            services.Configure<KestrelServerOptions>(options =>
+            {
+                options.Limits.MaxRequestBodySize = int.MaxValue;
+            });
+            services.Configure<FormOptions>(options =>
+            {
+                options.ValueLengthLimit = int.MaxValue;
+                options.MultipartBodyLengthLimit = int.MaxValue;
+                options.MultipartHeadersLengthLimit = int.MaxValue;
+            });
+
+            return services;
+        }
+    }
+}

--- a/server/Episememe.Api/Startup.cs
+++ b/server/Episememe.Api/Startup.cs
@@ -44,6 +44,8 @@ namespace Episememe.Api
                 services.AddJwtAuthentication(Configuration);
             }
 
+            services.ConfigureFileUploadLimits();
+
             services.AddControllers()
                 .AddJsonOptions(options =>
                 {

--- a/vue-client/src/assets/global.css
+++ b/vue-client/src/assets/global.css
@@ -1,6 +1,7 @@
 
 html {
     overflow: auto;
+    background-color: black;
 }
 
 .left {

--- a/vue-client/src/assets/global.css
+++ b/vue-client/src/assets/global.css
@@ -1,6 +1,5 @@
 
 html {
-    overflow: auto;
     background-color: black;
 }
 

--- a/vue-client/src/browsing/interfaces/IHasResolution.ts
+++ b/vue-client/src/browsing/interfaces/IHasResolution.ts
@@ -1,5 +1,5 @@
-import { ResolutionModes } from '../types/ResolutionModes';
+import { IResolution } from './IResolution';
 
 export interface IHasResolution {
-  getResolution(): Promise<ResolutionModes>;
+  getResolution(): Promise<IResolution>;
 }

--- a/vue-client/src/browsing/interfaces/IHasResolution.ts
+++ b/vue-client/src/browsing/interfaces/IHasResolution.ts
@@ -1,0 +1,5 @@
+import { ResolutionModes } from '../types/ResolutionModes';
+
+export interface IHasResolution {
+  getResolution(): Promise<ResolutionModes>;
+}

--- a/vue-client/src/browsing/interfaces/IResolution.ts
+++ b/vue-client/src/browsing/interfaces/IResolution.ts
@@ -1,0 +1,4 @@
+export interface IResolution {
+  width: number;
+  height: number;
+}

--- a/vue-client/src/browsing/media-gallery/MediaGallery.vue
+++ b/vue-client/src/browsing/media-gallery/MediaGallery.vue
@@ -69,6 +69,7 @@ export default class MediaGallery extends Mixins(FavoriteMediaProvider) {
       'landscape': this.resolutionMode === ResolutionModes.Landscape,
       'portrait': this.resolutionMode === ResolutionModes.Portrait,
       'aspect-fill': this.layoutMode === LayoutModes.AspectFill,
+      'aspect-fit': this.layoutMode === LayoutModes.AspectFit,
     };
   }
 
@@ -120,6 +121,7 @@ export default class MediaGallery extends Mixins(FavoriteMediaProvider) {
 }
 
 .media-gallery {
+  overflow-x: auto;
   background-color: black;
 
   display: flex;
@@ -130,6 +132,11 @@ export default class MediaGallery extends Mixins(FavoriteMediaProvider) {
 .media-gallery .media-instance {
   object-fit: contain;
   max-height: 90vh;
+}
+
+.media-gallery .media-instance.aspect-fit {
+  width: 100%;
+  height: 100%;
 }
 
 .media-gallery .media-instance.aspect-fill.portrait {

--- a/vue-client/src/browsing/media-gallery/MediaGallery.vue
+++ b/vue-client/src/browsing/media-gallery/MediaGallery.vue
@@ -9,7 +9,9 @@
         v-for='(item, index) in instances' :key='item.id'
         :active='index === currentlyBrowsedIndex'
         :instance='item'
-        class='media-instance'>
+        class='media-instance'
+        :class='additionalMediaInstanceClasses'
+        @resolution='resolutionMode = $event'>
       </MediaComponent>
     </div>
 
@@ -41,6 +43,8 @@ import MediaComponent from './media-component/MediaComponent.vue';
 import MediaSidebar from './media-sidebar/MediaSidebar.vue';
 import FavoriteMediaProvider from '../mixins/favorite-media-provider.service';
 import { IMediaInstance } from '../../shared/models/IMediaInstance';
+import { ResolutionModes } from '../types/ResolutionModes';
+import { LayoutModes } from '../types/LayoutModes';
 
 @Component({
   components: {
@@ -54,8 +58,18 @@ export default class MediaGallery extends Mixins(FavoriteMediaProvider) {
 
   sidebarOpen = false;
 
+  resolutionMode = ResolutionModes.Unknown;
+
   public get isQueryEmpty(): boolean {
     return this.instances == null || this.instances.length === 0;
+  }
+
+  public get additionalMediaInstanceClasses(): {[key: string]: boolean} {
+    return {
+      'landscape': this.resolutionMode === ResolutionModes.Landscape,
+      'portrait': this.resolutionMode === ResolutionModes.Portrait,
+      'aspect-fill': this.layoutMode === LayoutModes.AspectFill,
+    };
   }
 
   private updateInstance() {
@@ -63,6 +77,10 @@ export default class MediaGallery extends Mixins(FavoriteMediaProvider) {
       const currentInstance = this.instances[this.currentlyBrowsedIndex];
       this.$store.dispatch('gallery/updateCurrentMediaInstance', currentInstance);
     }
+  }
+
+  private get layoutMode() {
+    return this.$store.state.gallery.layoutMode as LayoutModes;
   }
 
   currentlyBrowsedIndex = 0;
@@ -112,6 +130,16 @@ export default class MediaGallery extends Mixins(FavoriteMediaProvider) {
 .media-gallery .media-instance {
   object-fit: contain;
   max-height: 90vh;
+}
+
+.media-gallery .media-instance.aspect-fill.portrait {
+  width: 100%;
+  max-height: 95%;
+}
+
+.media-gallery .media-instance.aspect-fill.landscape {
+  height: calc(100vh - 96px);
+  max-height: calc(100vh - 96px);
 }
 
 .previous-instance, .next-instance {

--- a/vue-client/src/browsing/media-gallery/MediaGallery.vue
+++ b/vue-client/src/browsing/media-gallery/MediaGallery.vue
@@ -127,8 +127,8 @@ export default class MediaGallery extends Mixins(FavoriteMediaProvider) {
 }
 
 .show-tags {
-  position: absolute;
-  top: 0;
+  position: fixed;
+  top: 64px;
   right: 0;
 }
 </style>

--- a/vue-client/src/browsing/media-gallery/media-component/MediaComponent.vue
+++ b/vue-client/src/browsing/media-gallery/media-component/MediaComponent.vue
@@ -86,8 +86,10 @@ export default class MediaComponent extends Mixins(ApiClientService) {
     } else if (this.getComponentType() === 'video') {
       const video = this.$refs.videoRef as VideoComponent;
       resolutionProvider = video;
-    } else
+    } else {
+      this.$emit('resolution', ResolutionModes.Unknown);
       return;
+    }
 
     resolutionProvider.getResolution().then(response =>
       this.$emit('resolution', this.computeResolutionMode(response))

--- a/vue-client/src/browsing/media-gallery/media-component/MediaComponent.vue
+++ b/vue-client/src/browsing/media-gallery/media-component/MediaComponent.vue
@@ -55,7 +55,7 @@ export default class MediaComponent extends Mixins(ApiClientService) {
     const dataType = this.instance?.dataType.toLowerCase() ?? '';
     if (['jpg', 'png', 'bmp', 'svg', 'jpeg', 'gif', 'webp'].includes(dataType))
       return 'image';
-    else if (['mp4', 'ogg', 'avi', 'mpeg'].includes(dataType))
+    else if (['mp4', 'ogg', 'avi', 'mpeg', 'webm'].includes(dataType))
       return 'video';
     else
       return 'download';

--- a/vue-client/src/browsing/media-gallery/media-component/MediaComponent.vue
+++ b/vue-client/src/browsing/media-gallery/media-component/MediaComponent.vue
@@ -31,6 +31,7 @@ import DownloadLinkComponent from './subcomponents/DownloadLinkComponent.vue';
 import ApiClientService from '../../../shared/mixins/api-client/api-client.service';
 import { ResolutionModes } from '../../types/ResolutionModes';
 import { IHasResolution } from '../../interfaces/IHasResolution';
+import { IResolution } from '../../interfaces/IResolution';
 
 @Component({
   components: {
@@ -88,8 +89,19 @@ export default class MediaComponent extends Mixins(ApiClientService) {
     } else
       return;
 
-    resolutionProvider.getResolution()
-      .then(response => this.$emit('resolution', response));
+    resolutionProvider.getResolution().then(response =>
+      this.$emit('resolution', this.computeResolutionMode(response))
+    );
+  }
+
+  private computeResolutionMode(resolution: IResolution): ResolutionModes {
+    const res = resolution;
+    if (res.width > res.height)
+      return ResolutionModes.Landscape;
+    else if (res.height > res.width)
+      return ResolutionModes.Portrait;
+    else
+      return ResolutionModes.Unknown;
   }
 }
 </script>

--- a/vue-client/src/browsing/media-gallery/media-component/subcomponents/DownloadLinkComponent.vue
+++ b/vue-client/src/browsing/media-gallery/media-component/subcomponents/DownloadLinkComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card>
+  <v-card class='card'>
     <v-card-title>{{ "#" + identifier }}</v-card-title>
 
     <v-card-text>
@@ -25,3 +25,10 @@ export default class DownloadLinkComponent extends Vue {
   identifier?: string;
 }
 </script>
+
+<style scoped>
+.card {
+  width: auto !important;
+  height: auto !important;
+}
+</style>

--- a/vue-client/src/browsing/media-gallery/media-component/subcomponents/ImageComponent.vue
+++ b/vue-client/src/browsing/media-gallery/media-component/subcomponents/ImageComponent.vue
@@ -1,16 +1,53 @@
 <template>
-  <img :src='url' :alt='alt'/>
+  <img :src='url' :alt='alt' ref='imageRef'/>
 </template>
 
 <script lang='ts'>
 import { Component, Prop, Vue } from 'vue-property-decorator';
+import { IHasResolution } from '../../../interfaces/IHasResolution';
+import { ResolutionModes } from '../../../types/ResolutionModes';
 
 @Component
-export default class ImageComponent extends Vue {
+export default class ImageComponent extends Vue implements IHasResolution {
   @Prop()
   url?: string;
 
   @Prop()
   alt?: string;
+
+  private resolutionMode: ResolutionModes = ResolutionModes.Unknown;
+
+  public getResolution(): Promise<ResolutionModes> {
+    const image = this.image;
+    if (image.complete) {
+      this.updateResolutionMode(image.naturalWidth, image.naturalHeight);
+      return Promise.resolve(this.resolutionMode);
+    } else {
+      // Note: might potentially cause issues if the function
+      // is called 2 times while an image is not yet loaded.
+      return new Promise((resolve, reject) => {
+        image.onload = () => {
+          this.updateResolutionMode(image.naturalWidth, image.naturalHeight);
+          resolve(this.resolutionMode);
+        }
+        image.onerror = reject;
+      });
+    }
+  }
+
+  private get image() {
+    return this.$refs.imageRef as HTMLImageElement;
+  }
+
+  private updateResolutionMode(width: number, height: number) {
+    let value: ResolutionModes;
+    if (width > height)
+      value = ResolutionModes.Landscape;
+    else if (height > width)
+      value = ResolutionModes.Portrait;
+    else
+      value = ResolutionModes.Unknown;
+    this.resolutionMode = value;
+  }
 }
 </script>

--- a/vue-client/src/browsing/media-gallery/media-component/subcomponents/ImageComponent.vue
+++ b/vue-client/src/browsing/media-gallery/media-component/subcomponents/ImageComponent.vue
@@ -5,7 +5,7 @@
 <script lang='ts'>
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { IHasResolution } from '../../../interfaces/IHasResolution';
-import { ResolutionModes } from '../../../types/ResolutionModes';
+import { IResolution } from '../../../interfaces/IResolution';
 
 @Component
 export default class ImageComponent extends Vue implements IHasResolution {
@@ -15,20 +15,20 @@ export default class ImageComponent extends Vue implements IHasResolution {
   @Prop()
   alt?: string;
 
-  private resolutionMode: ResolutionModes = ResolutionModes.Unknown;
+  private resolution: IResolution | null = null;
 
-  public getResolution(): Promise<ResolutionModes> {
+  public getResolution(): Promise<IResolution> {
     const image = this.image;
     if (image.complete) {
-      this.updateResolutionMode(image.naturalWidth, image.naturalHeight);
-      return Promise.resolve(this.resolutionMode);
+      const result = this.updateResolution(image.naturalWidth, image.naturalHeight);
+      return Promise.resolve(result);
     } else {
       // Note: might potentially cause issues if the function
       // is called 2 times while an image is not yet loaded.
       return new Promise((resolve, reject) => {
         image.onload = () => {
-          this.updateResolutionMode(image.naturalWidth, image.naturalHeight);
-          resolve(this.resolutionMode);
+          const result = this.updateResolution(image.naturalWidth, image.naturalHeight);
+          resolve(result);
         }
         image.onerror = reject;
       });
@@ -39,15 +39,10 @@ export default class ImageComponent extends Vue implements IHasResolution {
     return this.$refs.imageRef as HTMLImageElement;
   }
 
-  private updateResolutionMode(width: number, height: number) {
-    let value: ResolutionModes;
-    if (width > height)
-      value = ResolutionModes.Landscape;
-    else if (height > width)
-      value = ResolutionModes.Portrait;
-    else
-      value = ResolutionModes.Unknown;
-    this.resolutionMode = value;
+  private updateResolution(width: number, height: number): IResolution {
+    const result = { width: width, height: height };
+    this.resolution = result;
+    return result;
   }
 }
 </script>

--- a/vue-client/src/browsing/media-gallery/media-component/subcomponents/VideoComponent.vue
+++ b/vue-client/src/browsing/media-gallery/media-component/subcomponents/VideoComponent.vue
@@ -8,7 +8,7 @@
 <script lang='ts'>
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { IHasResolution } from '../../../interfaces/IHasResolution';
-import { ResolutionModes } from '../../../types/ResolutionModes';
+import { IResolution } from '../../../interfaces/IResolution';
 
 @Component
 export default class VideoComponent extends Vue implements IHasResolution {
@@ -24,28 +24,28 @@ export default class VideoComponent extends Vue implements IHasResolution {
   @Prop()
   active?: boolean;
 
-  private resolutionMode: ResolutionModes = ResolutionModes.Unknown;
+  private resolution: IResolution | null = null;
 
   mounted() {
     this.updateIsMuted();
     this.updateAutoloop();
   }
 
-  public getResolution(): Promise<ResolutionModes> {
+  public getResolution(): Promise<IResolution> {
     const video = this.video;
-    if (this.resolutionMode !== ResolutionModes.Unknown) {
+    if (this.resolution != null) {
       // Resolution has been requested before.
-      return Promise.resolve(this.resolutionMode);
+      return Promise.resolve(this.resolution as IResolution);
     } else if (video.videoWidth !== 0 && video.videoWidth != undefined) {
       // Video metadata loaded, but this is the 1st time resolution is requested.
-      this.updateResolutionMode(video.videoWidth, video.videoHeight);
-      return Promise.resolve(this.resolutionMode);
+      const result = this.updateResolution(video.videoWidth, video.videoHeight);
+      return Promise.resolve(result);
     } else {
       // Video metadata not yet loaded.
       return new Promise((resolve, reject) => {
         video.addEventListener('loadedmetadata', () => {
-          this.updateResolutionMode(video.videoWidth, video.videoHeight);
-          resolve(this.resolutionMode);
+          const result = this.updateResolution(video.videoWidth, video.videoHeight);
+          resolve(result);
         });
       });
     }
@@ -85,15 +85,10 @@ export default class VideoComponent extends Vue implements IHasResolution {
     return this.$refs.videoRef as HTMLVideoElement;
   }
 
-  private updateResolutionMode(width: number, height: number) {
-    let value: ResolutionModes;
-    if (width > height)
-      value = ResolutionModes.Landscape;
-    else if (height > width)
-      value = ResolutionModes.Portrait;
-    else
-      value = ResolutionModes.Unknown;
-    this.resolutionMode = value;
+  private updateResolution(width: number, height: number): IResolution {
+    const result = { width: width, height: height };
+    this.resolution = result;
+    return result;
   }
 }
 </script>

--- a/vue-client/src/browsing/media-gallery/media-component/subcomponents/VideoComponent.vue
+++ b/vue-client/src/browsing/media-gallery/media-component/subcomponents/VideoComponent.vue
@@ -7,9 +7,11 @@
 
 <script lang='ts'>
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { IHasResolution } from '../../../interfaces/IHasResolution';
+import { ResolutionModes } from '../../../types/ResolutionModes';
 
 @Component
-export default class VideoComponent extends Vue {
+export default class VideoComponent extends Vue implements IHasResolution {
   @Prop()
   url?: string;
 
@@ -22,9 +24,31 @@ export default class VideoComponent extends Vue {
   @Prop()
   active?: boolean;
 
+  private resolutionMode: ResolutionModes = ResolutionModes.Unknown;
+
   mounted() {
     this.updateIsMuted();
     this.updateAutoloop();
+  }
+
+  public getResolution(): Promise<ResolutionModes> {
+    const video = this.video;
+    if (this.resolutionMode !== ResolutionModes.Unknown) {
+      // Resolution has been requested before.
+      return Promise.resolve(this.resolutionMode);
+    } else if (video.videoWidth !== 0 && video.videoWidth != undefined) {
+      // Video metadata loaded, but this is the 1st time resolution is requested.
+      this.updateResolutionMode(video.videoWidth, video.videoHeight);
+      return Promise.resolve(this.resolutionMode);
+    } else {
+      // Video metadata not yet loaded.
+      return new Promise((resolve, reject) => {
+        video.addEventListener('loadedmetadata', () => {
+          this.updateResolutionMode(video.videoWidth, video.videoHeight);
+          resolve(this.resolutionMode);
+        });
+      });
+    }
   }
 
   @Watch('active')
@@ -57,8 +81,19 @@ export default class VideoComponent extends Vue {
     this.video.loop = this.autoloop;
   }
 
-  private get video(): HTMLMediaElement {
-    return this.$refs.videoRef as HTMLMediaElement;
+  private get video(): HTMLVideoElement {
+    return this.$refs.videoRef as HTMLVideoElement;
+  }
+
+  private updateResolutionMode(width: number, height: number) {
+    let value: ResolutionModes;
+    if (width > height)
+      value = ResolutionModes.Landscape;
+    else if (height > width)
+      value = ResolutionModes.Portrait;
+    else
+      value = ResolutionModes.Unknown;
+    this.resolutionMode = value;
   }
 }
 </script>

--- a/vue-client/src/browsing/media-gallery/media-sidebar/MediaSidebar.vue
+++ b/vue-client/src/browsing/media-gallery/media-sidebar/MediaSidebar.vue
@@ -2,7 +2,7 @@
   <v-navigation-drawer
     v-model='isOpen'
     color='secondary darken-1'
-    absolute temporary>
+    fixed temporary>
 
     <span v-if='instance == null'>No media instance specified.</span>
     <v-list v-else class='ma-1'>

--- a/vue-client/src/browsing/settings-menu/SettingsMenu.vue
+++ b/vue-client/src/browsing/settings-menu/SettingsMenu.vue
@@ -12,6 +12,7 @@
     </template>
 
     <RevisionMenuButton @click='startRevision' />
+    <MediaLayoutMenuButton @click='toggleLayoutMode' />
     <VolumeMenuButton @click='toggleVolume' />
     <AutoloopMenuButton @click='toggleAutoloop' />
     <FavoriteMenuButton />
@@ -26,6 +27,7 @@ import RevisionMenuButton from './buttons/RevisionMenuButton.vue';
 import VolumeMenuButton from './buttons/VolumeMenuButton.vue';
 import AutoloopMenuButton from './buttons/AutoloopMenuButton.vue';
 import FavoriteMenuButton from './buttons/FavoriteMenuButton.vue';
+import MediaLayoutMenuButton from './buttons/MediaLayoutMenuButton.vue';
 
 @Component({
   components: {
@@ -34,6 +36,7 @@ import FavoriteMenuButton from './buttons/FavoriteMenuButton.vue';
     VolumeMenuButton,
     AutoloopMenuButton,
     FavoriteMenuButton,
+    MediaLayoutMenuButton,
   }
 })
 export default class SettingsMenu extends Vue {
@@ -53,6 +56,10 @@ export default class SettingsMenu extends Vue {
 
   toggleAutoloop() {
     this.$store.dispatch('gallery/toggleAutoloop');
+  }
+
+  toggleLayoutMode() {
+    this.$store.dispatch('gallery/toggleLayoutMode');
   }
 }
 </script>

--- a/vue-client/src/browsing/settings-menu/SettingsMenu.vue
+++ b/vue-client/src/browsing/settings-menu/SettingsMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <v-speed-dial
-    absolute
+    fixed
     v-model='speedDialIsOpen'
     :right='true' :bottom='true'
     :open-on-hover='true'>

--- a/vue-client/src/browsing/settings-menu/buttons/BaseSettingsMenuButton.vue
+++ b/vue-client/src/browsing/settings-menu/buttons/BaseSettingsMenuButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-tooltip left>
+  <v-tooltip left :key='label'>
     <template v-slot:activator='{ on }'>
       <v-btn @click='$emit("click", $event)'
         v-on='on' fab small color='secondary' @click.stop>

--- a/vue-client/src/browsing/settings-menu/buttons/MediaLayoutMenuButton.vue
+++ b/vue-client/src/browsing/settings-menu/buttons/MediaLayoutMenuButton.vue
@@ -1,0 +1,39 @@
+<template>
+  <BaseSettingsMenuButton
+    :label='currentState.label'
+    :icon='currentState.icon'
+    @click='$emit("click", $event)' />
+</template>
+
+<script lang='ts'>
+import { Component, Vue } from 'vue-property-decorator';
+import { LayoutModes } from '../../types/LayoutModes';
+import BaseSettingsMenuButton from './BaseSettingsMenuButton.vue';
+
+type ButtonState = { label: string; icon: string };
+type ButtonStates = { [key in LayoutModes]: ButtonState };
+
+@Component({
+  components: {
+    BaseSettingsMenuButton
+  }
+})
+export default class MediaLayoutMenuButton extends Vue {
+
+  get currentState(): ButtonState {
+    const currentMode = this.$store.state.gallery.layoutMode as LayoutModes;
+    return this.states[currentMode];
+  }
+
+  private states: ButtonStates = {
+    [LayoutModes.AspectFit]: {
+      label: 'Aspect fit',
+      icon: 'mdi-aspect-ratio'
+    },
+    [LayoutModes.AspectFill]: {
+      label: 'Aspect fill',
+      icon: 'mdi-arrow-expand-all'
+    },
+  };
+}
+</script>

--- a/vue-client/src/browsing/settings-menu/buttons/MediaLayoutMenuButton.vue
+++ b/vue-client/src/browsing/settings-menu/buttons/MediaLayoutMenuButton.vue
@@ -26,6 +26,10 @@ export default class MediaLayoutMenuButton extends Vue {
   }
 
   private states: ButtonStates = {
+    [LayoutModes.OriginalOrFit]: {
+      label: 'Original or shrink to fit',
+      icon: 'mdi-arrow-collapse-all'
+    },
     [LayoutModes.AspectFit]: {
       label: 'Aspect fit',
       icon: 'mdi-aspect-ratio'

--- a/vue-client/src/browsing/types/LayoutModes.ts
+++ b/vue-client/src/browsing/types/LayoutModes.ts
@@ -1,4 +1,5 @@
 export enum LayoutModes {
+  OriginalOrFit,
   AspectFit,
   AspectFill,
 }

--- a/vue-client/src/browsing/types/LayoutModes.ts
+++ b/vue-client/src/browsing/types/LayoutModes.ts
@@ -1,0 +1,4 @@
+export enum LayoutModes {
+  AspectFit,
+  AspectFill,
+}

--- a/vue-client/src/browsing/types/ResolutionModes.ts
+++ b/vue-client/src/browsing/types/ResolutionModes.ts
@@ -1,0 +1,5 @@
+export enum ResolutionModes {
+  Unknown,
+  Landscape,
+  Portrait,
+}

--- a/vue-client/src/store/modules/gallery.module.ts
+++ b/vue-client/src/store/modules/gallery.module.ts
@@ -1,5 +1,6 @@
 import { Module } from 'vuex';
 import { IMediaInstance } from '@/shared/models/IMediaInstance';
+import { LayoutModes } from '@/browsing/types/LayoutModes';
 
 export const gallery: Module<any, any> = {
   namespaced: true,
@@ -7,6 +8,7 @@ export const gallery: Module<any, any> = {
     currentMediaInstance: null,
     isMuted: false,
     autoloop: true,
+    layoutMode: LayoutModes.AspectFit,
   }),
   mutations: {
     setCurrentMediaInstance(state, newInstance: IMediaInstance) {
@@ -17,7 +19,10 @@ export const gallery: Module<any, any> = {
     },
     setAutoloop(state, newValue: boolean) {
       state.autoloop = newValue;
-    }
+    },
+    setLayoutMode(state, newMode: LayoutModes) {
+      state.layoutMode = newMode;
+    },
   },
   actions: {
     updateCurrentMediaInstance({ commit }, instance: IMediaInstance) {
@@ -28,7 +33,12 @@ export const gallery: Module<any, any> = {
     },
     toggleAutoloop({ commit, state }) {
       commit('setAutoloop', !state.autoloop);
-    }
+    },
+    toggleLayoutMode({ commit, state }) {
+      const newValue = state.layoutMode === LayoutModes.AspectFit
+        ? LayoutModes.AspectFill : LayoutModes.AspectFit;
+      commit('setLayoutMode', newValue);
+    },
   },
   getters: {
     currentMediaId: state => {

--- a/vue-client/src/store/modules/gallery.module.ts
+++ b/vue-client/src/store/modules/gallery.module.ts
@@ -8,7 +8,7 @@ export const gallery: Module<any, any> = {
     currentMediaInstance: null,
     isMuted: false,
     autoloop: true,
-    layoutMode: LayoutModes.AspectFit,
+    layoutMode: LayoutModes.OriginalOrFit,
   }),
   mutations: {
     setCurrentMediaInstance(state, newInstance: IMediaInstance) {
@@ -35,8 +35,13 @@ export const gallery: Module<any, any> = {
       commit('setAutoloop', !state.autoloop);
     },
     toggleLayoutMode({ commit, state }) {
-      const newValue = state.layoutMode === LayoutModes.AspectFit
-        ? LayoutModes.AspectFill : LayoutModes.AspectFit;
+      const map: { [key in LayoutModes]: LayoutModes } = {
+        [LayoutModes.OriginalOrFit]: LayoutModes.AspectFit,
+        [LayoutModes.AspectFit]: LayoutModes.AspectFill,
+        [LayoutModes.AspectFill]: LayoutModes.OriginalOrFit,
+      };
+
+      const newValue = map[state.layoutMode as LayoutModes];
       commit('setLayoutMode', newValue);
     },
   },


### PR DESCRIPTION
3 modes are now available:
- **Original or shrink to fit:** display media in it's original dimensions **or** shrink to fit available space
- **Aspect fit:** resize to fit maximum available space
- **Aspect fill:** resize media to fit the window either vertically or horizontally. E.g. if a media component is very tall, a vertical scrollbar may appear.
Closes #81 